### PR TITLE
bump version and clojure to 1.9 to alleviate spec error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject pegasus "0.7.0"
+(defproject pegasus "0.7.1"
   :description "A scaleable production-ready crawler in clojure"
   :url "http://github.com/shriphani/pegasus"
   :license {:name "Eclipse Public License"
@@ -15,7 +15,7 @@
                  [factual/durable-queue "0.1.5"]
                  [me.raynes/fs "1.4.6"]
                  [org.bovinegenius/exploding-fish "0.3.4"]
-                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojure "1.9.0"]
                  [org.clojure/core.async "0.4.474"]
                  [org.clojure/tools.namespace "0.2.11"]
                  [prismatic/schema "1.1.0"]


### PR DESCRIPTION
spec issues an error with the latest core.async unless on clojure 1.9.